### PR TITLE
Py3k compat

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = stsci.imagemanip
-version = 1.1.1.dev
+version = 1.1.2.dev
 author = Christopher Hanley
 author-email = help@stsci.edu
 summary = STScI general image manipulation tools

--- a/stsci/imagemanip/__init__.py
+++ b/stsci/imagemanip/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-import interp2d
+from . import interp2d
 
 from .version import *
 


### PR DESCRIPTION
Prevents the following error:

``` python
$ python
Python 3.5.1 |Continuum Analytics, Inc.| (default, Dec  7 2015, 11:16:01)
[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import stsci.imagemanip
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jhunk/forks/stsci.imagemanip/stsci/imagemanip/__init__.py", line 3, in <module>
    import interp2d
ImportError: No module named 'interp2d'
```
